### PR TITLE
Adjust jenkins build

### DIFF
--- a/jenkins/Jenkinsfile.build
+++ b/jenkins/Jenkinsfile.build
@@ -52,13 +52,13 @@ pipeline {
             steps {
                 script {
                     if ("${params.BUILD_DEST}" == "prod") {
-                        targetDomain = "s3://water-visualizations-prod-website/visualizations/vizlab-home"
+                        targetDomain = "s3://water-visualizations-prod-website/visualizations"
                     }
                     else if ("${params.BUILD_DEST}" == "beta") {
-                        targetDomain = "s3://water-visualizations-beta-website/visualizations/vizlab-home"
+                        targetDomain = "s3://water-visualizations-beta-website/visualizations"
                     }
                     else {
-                        targetDomain = "s3://water-visualizations-test-website/visualizations/vizlab-home"
+                        targetDomain = "s3://water-visualizations-test-website/visualizations"
                     }
                 }
                 sh """

--- a/jenkins/Jenkinsfile.build
+++ b/jenkins/Jenkinsfile.build
@@ -62,7 +62,6 @@ pipeline {
                     }
                 }
                 sh """
-                    aws s3 rm "${targetDomain}" --recursive
                     aws s3 cp "$WORKSPACE/dist" "${targetDomain}" --recursive
                 """
             }


### PR DESCRIPTION
This PR updates the Jenkins build process for vizlab home to
1) build the site at `labs.waterdata.usgs.gov/visualizations` instead of `labs.waterdata.usgs.gov/visualizations/vizlab-home`
2) **_NOT_** delete the target domain when building the site, but instead only copy the site files to the `visualizations` bucket on s3, which overwrites only those site files.

I tested this by rebuilding [beta](https://labs-beta.waterdata.usgs.gov/visualizations/index.html#/) at `labs.waterdata.usgs.gov/visualizations`.

The s3 bucket still contains the subdirectories for the other beta sites:
![image](https://github.com/DOI-USGS/vizlab-home/assets/54007288/a5a26222-696e-4c6f-b066-3c3d7c04351a)
