### PR TITLE
add ggplot blog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6136,14 +6136,24 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001251",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
-      "integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==",
+      "version": "1.0.30001519",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001519.tgz",
+      "integrity": "sha512-0QHgqR+Jv4bxHMp8kZ1Kn8CH55OikjKJ6JmKkZYP1F3D7w+lnFXF70nG5eNfsZS89jadi5Ywy5UCSKLAglIRkg==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ]
     },
     "node_modules/case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",

--- a/src/components/WhatsNew.vue
+++ b/src/components/WhatsNew.vue
@@ -31,6 +31,30 @@
             <!-- blog list item -->
             <li>
               <span class="date-text">
+                07/21/2023:
+              </span> 
+              Jazz up your ggplots!
+              <a
+                href="https://waterdata.usgs.gov/blog/ggplot-jazz/"
+                target="_blank"
+              >
+                <span class="arrow">
+                  Read &#8594;
+                </span>
+              </a>
+              <!-- include thumbnail of most recent blog post - for now, water cycle to be distinct from the 'recent' image -->
+              <div class="thumbnail-container">
+                <img 
+                  class="blog-thumbnail"
+                  src="https://waterdata.usgs.gov/blog/static/ggplot-extensions/ggplot-extensions-banner.png" 
+                  alt="Musical notes drawn with the center of the notes containing data viz examples"
+                >
+              </div>
+            </li>
+            <!-- end blog list item -->
+            <!-- blog list item -->
+            <li>
+              <span class="date-text">
                 05/3/2023:
               </span> 
               The 30 Day Chart Challenge with the USGS VizLab
@@ -42,14 +66,6 @@
                   Read &#8594;
                 </span>
               </a>
-              <!-- include thumbnail of most recent blog post - for now, water cycle to be distinct from the 'recent' image -->
-              <div class="thumbnail-container">
-                <img 
-                  class="blog-thumbnail"
-                  src="https://labs.waterdata.usgs.gov/visualizations/thumbnails/chart-challenge-23-thumbnail.webp" 
-                  alt="Collage of 25 chart challenge entries for the USGS Data Science branch and collaborators. Entries are arranged so that charts with a dark theme are in the lower right (i.e., charts on dark backgrounds) and they create a gradient to charts that are lighter (i.e., on a white background) in the upper left."
-                >
-              </div>
             </li>
             <!-- end blog list item -->
             <!-- blog list item -->


### PR DESCRIPTION
Changes made:
-----------
Updating the blog section to include the latest ggplot blog. I added the link and thumbnail for the blog, and moved the 30 day chart challenge blog lower, with no thumbnail. I also added a minor update to one of the dependencies.

To test this run `npm run serve` from the directory.

Expected result:
<img width="1734" alt="image" src="https://github.com/DOI-USGS/vizlab-home/assets/17803537/42e4e9a5-9050-4b1e-a023-747c4e716138">



Testing:
----------------------------
Before making this pull request, I:
- [ ] Cleaned the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Made sure all tests run
- [ ] Ran WAVE plugin 508 compliance tool

I can confirm this has been checked on:
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)
