### PR TITLE
Adds dates to the river conditions cards, removes handleSlideClick function for now

### DIFF
--- a/src/assets/content/FlowTiles.js
+++ b/src/assets/content/FlowTiles.js
@@ -5,7 +5,7 @@ export default {
         //create a new folder with the name YYYY/MM (example 2024_01) and upload the png into that folder
         //add a new object below and update the folder with the name you created, the image_basename with the file name, and the image_alt (taken from twitter)
         {
-            id: '1',
+            id: '14',
             author: '',
             folder: '2024_02/',
             twitter_url: 'https://twitter.com/USGS_DataSci/status/1765078810725413349',
@@ -13,7 +13,7 @@ export default {
             image_type: 'png',
             image_alt: 'A tile map of the US showing streamgages by flow levels through the month of February 2024. For each state, an area chart shows the proportion of streamgages in wet, normal, or dry conditions. Streamflow conditions are quantified using percentiles comparing the past month’s flow levels to the historic record for each streamgage. During the month of February, wet conditions persisted across much of California as an atmospheric river approached. Wet conditions persisted for states such as Mississippi, Alabama, Georgia, and Tennesse as severe weather and heavy rain brought wet conditions. '
         },{
-            id: '2',
+            id: '13',
             author: '',
             folder: '2024_01/',
             twitter_url: 'https://twitter.com/USGS_DataSci/status/1754552632742752744',
@@ -22,7 +22,7 @@ export default {
             image_alt: 'A tile map of the US showing streamgages by flow levels through the month of January 2024. For each state, an area chart shows the proportion of streamgages in wet, normal, or dry conditions. Streamflow conditions are quantified using percentiles comparing the past month’s flow levels to the historic record for each streamgage. During the month of January, wet conditions persisted across much of the Eastern U.S. and Pacific Coast as a storm system and low-pressure system approached, respectively. Wet conditions persisted for states such as Connecticut, Rhode Island, Vermont, New Hampshire, Massachusetts, New Jersey, New York, Oregon, Washington, and California. States such as Iowa, Nebraska, and Colorado saw relatively dry conditions.'
         },
         {
-            id: '3',
+            id: '12',
             author: '',
             folder: '2023_12/',
             twitter_url: 'https://twitter.com/USGS_DataSci/status/1742622815944356338',
@@ -31,7 +31,7 @@ export default {
             image_alt: 'A tile map of the US showing streamgages by flow levels through the month of December 2023. For each state, an area chart shows the proportion of streamgages in wet, normal, or dry conditions. Streamflow conditions are quantified using percentiles comparing the past month’s flow levels to the historic record for each streamgage. During the month of December, much of the Northeastern U.S. and Pacific Northwest saw wet conditions for stats such as Connecticut, Rhode Island, Vermont, New Hampshire, Massachusetts, New Jersey, New York, Oregon, and Washington, while states such as Louisiana, Mississippi, and Alabama in the Southern U.S. saw relatively dry conditions.'
         },
         {
-            id: '4',
+            id: '11',
             author: '',
             folder: '2023_11/',
             twitter_url: 'https://twitter.com/USGS_DataSci/status/1731718693686563238',
@@ -40,7 +40,7 @@ export default {
             image_alt: 'A tile map of the US showing streamgages by flow levels through the month of November 2023. For each state, an area chart shows the proportion of streamgages in wet, normal, or dry conditions. Streamflow conditions are quantified using percentiles comparing the past month’s flow levels to the historic record for each streamgage. During the month of November, much of the Northeastern U.S. saw wet conditions for stats such as Connecticut, Rhode Island, Vermont, New Hampshire and Maine, while states such as Louisiana, Mississippi, and Alabama in the Southern U.S. saw dry conditions.'
         },
         {
-            id: '5',
+            id: '10',
             author: '',
             folder: '2023_10/',
             twitter_url: 'https://twitter.com/USGS_DataSci/status/1721583036540538940',
@@ -49,7 +49,7 @@ export default {
             image_alt: 'A tile map of the US showing streamgages by flow levels through the month of October 2023. For each state, an area chart shows the proportion of streamgages in wet, normal, or dry conditions. Streamflow conditions are quantified using percentiles comparing the past month’s flow levels to the historic record for each streamgage. During the month of October, much of the Central and Southern U.S. saw dry conditions, while regions such as New England and Puerto Rico saw wet conditions.'
         },
         {
-            id: '6',
+            id: '9',
             author: '',
             folder: '2023_09/',
             twitter_url: 'https://twitter.com/USGS_DataSci/status/1711856031322538063',
@@ -58,7 +58,7 @@ export default {
             image_alt: 'A tile map of the US showing streamgages by flow levels through the month of September 2023. For each state, an area chart shows the proportion of streamgages in wet, normal, or dry conditions. Streamflow conditions are quantified using percentiles comparing the past month’s flow levels to the historic record for each streamgage. During the month of September, much of the Central U.S. and parts of the Pacific Northwest, such as Oregon and Washington, saw dry conditions. Later in the month, parts of New England experienced wet conditions for states such as Maine, Massachusetts, Connecticut, Rhode Island and Delaware.'
         },
         {
-            id: '7',
+            id: '8',
             author: '',
             folder: '2023_08/',
             twitter_url: 'https://twitter.com/USGS_DataSci/status/1700176429202506152',
@@ -67,7 +67,7 @@ export default {
             image_alt: 'A tile map of the US showing streamgages by flow levels through the month of August 2023. For each state, an area chart shows the proportion of streamgages in wet, normal, or dry conditions. Streamflow conditions are quantified using percentiles comparing the past month’s flow levels to the historic record for each streamgage. During the month of August, wetter than normal conditions persisted for part of New England in states such as Vermont, New Hampshire, and Maine. Concurrently, much of the U.S. saw dry conditions, namely, states in the Pacific Northwest, such as Washington and Oregon, as well as South Central U.S. such as Texas and Louisiana. '
         },
         {
-            id: '8',
+            id: '7',
             author: '',
             folder: '2023_07/',
             twitter_url: 'https://twitter.com/USGS_DataSci/status/1687206598052302851',
@@ -76,7 +76,7 @@ export default {
             image_alt: 'A tile map of the US showing streamgages by flow levels through the month of July 2023. For each state, an area chart shows the proportion of streamgages in wet, normal, or dry conditions. Streamflow conditions are quantified using percentiles comparing the past month’s flow levels to the historic record for each streamgage. During the month of July, wetter than normal conditions persisted for much of New England for states such as Vermont, New Hampshire, Massachusetts, and Connecticut. Concurrently, states in the Pacific Northwest, such as Washington and Oregon, saw dry conditions.'
         },
         {
-            id: '9',
+            id: '6',
             author: '',
             folder: '2023_06/',
             twitter_url: 'https://twitter.com/USGS_DataSci/status/1678795881225781248',
@@ -85,7 +85,7 @@ export default {
             image_alt: 'A tile map of the US showing streamgages by flow levels through the month of June 2023. For each state, an area chart shows the proportion of streamgages in wet, normal, or dry conditions. Streamflow conditions are quantified using percentiles comparing the past month’s flow levels to the historic record for each streamgage. During the month of June, wetter than normal conditions persisted for much of the Intermountain West for states such as Utah, Colorado, Nevada, and Wyoming, while the Eastern U.S. saw dry conditions.'
         },
         { 
-            id: '10',
+            id: '5',
             author: '',
             folder: '2023_05/',
             twitter_url: 'https://twitter.com/USGS_DataSci/status/1666168500283645953',
@@ -94,7 +94,7 @@ export default {
             image_alt: 'May 2023 Streamflow'
         },
         {
-            id: '11',
+            id: '4',
             author: '',
             folder: '2023_04/',
             twitter_url: 'https://twitter.com/USGS_DataSci/status/1653869069429522432',
@@ -103,7 +103,7 @@ export default {
             image_alt: 'A tile map of the US showing streamgages by flow levels through the month of May 2023. For each state, an area chart shows the proportion of streamgages in wet, normal, or dry conditions. Streamflow conditions are quantified using percentiles comparing the past month’s flow levels to the historic record for each streamgage. During the month of May, wetter than normal conditions persisted for much of the Western U.S., while the Southern Plains, such as Nebraska and Kansas, and parts of the Eastern U.S., such as the Mid-Atlantic and Florida, saw drought conditions.'
         },
         {
-            id: '12',
+            id: '3',
             author: '',
             folder: '2023_03/',
             twitter_url: 'https://twitter.com/USGS_DataSci/status/1643383570965184514',
@@ -112,7 +112,7 @@ export default {
             image_alt: 'A tile map of the US showing streamgages by flow levels through the month of March 2023. For each state, an area chart shows the proportion of streamgages in wet, normal, or dry conditions. Streamflow conditions are quantified using percentiles comparing the past month’s flow levels to the historic record for each streamgage. During the month of March, storms brought wetter than normal conditions for much of the U.S. Concurrently, large parts of California, the Southwest and the Mississippi River Basin saw heightened precipitation, while much of the Northwest and Northern Plaines remain dry.'
         },
         {
-            id: '13',
+            id: '2',
             author: '',
             folder: '2023_02/',
             twitter_url: 'https://twitter.com/USGS_DataSci/status/1632802669906518018',
@@ -121,7 +121,7 @@ export default {
             image_alt: 'A tile map of the US showing streamgages by flow levels through the month of February 2023. For each state, an area chart shows the proportion of streamgages in wet, normal, or dry conditions. Streamflow conditions are quantified using percentiles comparing the past month’s flow levels to the historic record for each streamgage. During the month of January, winter storms brought wetter than normal conditions for much of the U.S. Concurrently, California saw wetter than normal conditions as winter storms brought heightened precipitation. At the national scale, many sites experienced wetter than normal conditions as winter storms conditions persisted across the West Coast and Eastern U.S.'
         },
         {
-            id: '14',
+            id: '1',
             author: '',
             folder: '2023_01/',
             twitter_url: 'https://twitter.com/USGS_DataSci/status/1622635541073387520',

--- a/src/assets/content/RiverConditions.js
+++ b/src/assets/content/RiverConditions.js
@@ -1,8 +1,8 @@
 export default {
     riverConditionsCharts: [
         {
-            id: '1',
-            name: 'Oct-Dec 2024',
+            id: '13',
+            name: 'October 1 - December 31, 2024',
             drupal_url: 'https://www.usgs.gov/media/videos/us-river-conditions-october-december-2023',
             folder: 'FY24_Q1/',
             video_basename: 'river_conditions_oct_dec_2023_insta',
@@ -12,8 +12,8 @@ export default {
         }
         ,
         {
-            id: '2',
-            name: 'Jul-Sep 2023',
+            id: '12',
+            name: 'July 1 - September 30, 2023',
             drupal_url: 'https://www.usgs.gov/media/videos/us-river-conditions-july-september-2023',
             folder: 'FY23_Q4/',
             video_basename: 'river_conditions_jul_sep_2023_insta',
@@ -22,8 +22,8 @@ export default {
             image_alt: 'U.S. River Conditions from July 1, 2023 to September 30, 2023 at USGS streamgages.'
         },
         {
-            id: '3',
-            name: 'Apr-Jun 2023',
+            id: '11',
+            name: 'April 1 - June 30, 2023',
             drupal_url: 'https://www.usgs.gov/media/videos/us-river-conditions-april-june-2023',
             folder: 'FY23_Q3/',
             video_basename: 'river_conditions_apr_jun_2023_insta',
@@ -32,8 +32,8 @@ export default {
             image_alt: 'U.S. River Conditions from April 1, 2023 to June 30, 2023 at USGS streamgages.'
         },
         {
-            id: '4',
-            name: 'Jan-Mar 2023',
+            id: '10',
+            name: 'January 1 - March 31, 2023',
             drupal_url: 'https://www.usgs.gov/media/videos/us-river-conditions-january-march-2023',
             folder: 'FY23_Q2/',
             video_basename: 'river_conditions_jan_mar_2023_insta',
@@ -42,8 +42,8 @@ export default {
             image_alt: 'U.S. River Conditions from January 1, 2023 to March 31, 2023 at USGS streamgages.'
         },
         {
-            id: '5',
-            name: 'Oct-Dec 2022',
+            id: '9',
+            name: 'October 1 - December 31, 2022',
             drupal_url: 'https://www.usgs.gov/media/videos/us-river-conditions-october-december-2022',
             folder: 'FY23_Q1/',
             video_basename: 'river_conditions_oct_dec_2022_insta',
@@ -52,8 +52,8 @@ export default {
             image_alt: 'U.S. River Conditions from October 1, 2022 to December 31, 2022 at USGS streamgages.'
         },
         {
-            id: '6',
-            name: 'Jul-Sep 2022',
+            id: '8',
+            name: 'July 1 - September 30, 2022',
             drupal_url: 'https://www.usgs.gov/media/videos/us-river-conditions-july-september-2022',
             folder: 'FY22_Q4/',
             video_basename: 'river_conditions_jul_sep_2022_insta',
@@ -63,7 +63,7 @@ export default {
         },
         {
             id: '7',
-            name: 'Apr-Jun 2022',
+            name: 'April 1 - June 30, 2022',
             drupal_url: 'https://www.usgs.gov/media/videos/us-river-conditions-april-june-2022',
             folder: 'FY22_Q3/',
             video_basename: 'river_conditions_apr_jun_2022_insta',
@@ -72,8 +72,8 @@ export default {
             image_alt: 'U.S. River Conditions from April 1, 2022 to June 30, 2022 at USGS streamgages.'
         },
         {
-            id: '8',
-            name: 'Jan-Mar 2022',
+            id: '6',
+            name: 'January 1 - March 31, 2022',
             drupal_url: 'https://www.usgs.gov/media/videos/us-river-conditions-january-march-2022',
             folder: 'FY22_Q2/',
             video_basename: 'river_conditions_jan_mar_2022_insta',
@@ -82,8 +82,8 @@ export default {
             image_alt: 'U.S. River Conditions from January 1, 2022 to March 31, 2022 at USGS streamgages.'
         },
         { 
-            id: '9',
-            name: 'Oct-Dec 2021',
+            id: '5',
+            name: 'October 1 - December 31, 2021',
             drupal_url: 'https://www.usgs.gov/media/videos/us-river-conditions-october-december-2021',
             folder: 'FY22_Q1/',
             video_basename: 'river_conditions_oct_dec_2021_insta',
@@ -92,8 +92,8 @@ export default {
             image_alt: 'U.S. River Conditions from October 1, 2021 to December 31, 2021 at USGS streamgages.'
         },
         {
-            id: '10',
-            name: 'Jan-Mar 2021',
+            id: '4',
+            name: 'January 1 - March 31, 2021',
             drupal_url: 'https://www.usgs.gov/media/videos/us-river-conditions-july-september-2021',
             folder: 'FY21_Q4/',
             video_basename: 'river_conditions_jul_sep_2021_insta',
@@ -102,8 +102,8 @@ export default {
             image_alt: 'U.S. River Conditions from July 1, 2021 to September 30, 2021 at USGS streamgages.'
         },
         {
-            id: '11',
-            name: 'Apr-Jun 2021',
+            id: '3',
+            name: 'April 1 - June 30, 2021',
             drupal_url: 'https://www.usgs.gov/media/videos/us-river-conditions-april-june-2021',
             folder: 'FY21_Q3/',
             video_basename: 'river_conditions_apr_jun_2021_insta',
@@ -112,8 +112,8 @@ export default {
             image_alt: 'U.S. River Conditions from April 1, 2021 to June 30, 2021 at USGS streamgages.'
         },
         {
-            id: '12',
-            name: 'Jan-Mar 2021',
+            id: '2',
+            name: 'January 1 - March 31, 2021',
             drupal_url: 'https://www.usgs.gov/media/videos/us-river-conditions-january-march-2021',
             folder: 'FY21_Q2/',
             video_basename: 'river_conditions_jan_mar_2021_insta',
@@ -122,8 +122,8 @@ export default {
             image_alt: 'U.S. River Conditions from January 1, 2021 to March 31, 2021 at USGS streamgages.'
         },
         {
-            id: '13',
-            name: 'Oct-Dec 2020',
+            id: '1',
+            name: 'October 1 - December 31, 2020',
             drupal_url: 'https://www.usgs.gov/media/videos/us-river-conditions-october-december-2020',
             folder: 'FY21_Q1/',
             video_basename: 'river_conditions_oct_dec_2020_insta',

--- a/src/components/PortfolioAccordions.vue
+++ b/src/components/PortfolioAccordions.vue
@@ -75,7 +75,7 @@
         <h4
           id="head-river-conditions"
         >
-          U.S. River Conditions (quarterly)<a
+          U.S. River Conditions (quarterly) <a
           href="https://github.com/DOI-USGS/gage-conditions-gif"
           target="_blank"
           style="font-style: italic; font-size: 0.9em"

--- a/src/components/RiverConditions_Carousel.vue
+++ b/src/components/RiverConditions_Carousel.vue
@@ -9,10 +9,11 @@
             navigation-enabled
             :speed="800"        >
             <slide
-                v-for="chart in charts"
+                v-for="(chart, index) in charts"
                 :id="`river-conditions-${chart.id}`"
                 :key="chart.id"
-                class="slide">
+                class="slide"
+                @slideclick="handleSlideClick(index)">
                 <div class="slider-video-container">
                     <div class="video-border">
                         <center>
@@ -57,6 +58,9 @@
             },
             getThumbnailUrl(folder, thumbnail) {
                 return 'https://labs.waterdata.usgs.gov/visualizations/river-conditions/' + folder + thumbnail;
+            },
+            handleSlideClick (index) {
+                window.open(this.charts[index].drupal_url, "_blank");
             }
         }
     }

--- a/src/components/RiverConditions_Carousel.vue
+++ b/src/components/RiverConditions_Carousel.vue
@@ -12,13 +12,17 @@
                 v-for="chart in charts"
                 :id="`river-conditions-${chart.id}`"
                 :key="chart.id"
-                class="slide"
-                @slideclick="handleSlideClick">
+                class="slide">
                 <div class="slider-video-container">
-                    <video width="100%" :poster="getThumbnailUrl(chart.folder, chart.image_thumbnail)" onmouseover="this.play();this.setAttribute('controls','controls')" onmouseout="this.load();this.removeAttribute('controls')"> <!-- use atuoplay muted to get videos to autoplay -->
-                        <source :src="getVideoUrl(chart.folder, chart.video_basename, chart.video_type)" type="video/mp4">
-                        Your browser does not support the video tag.
-                    </video>
+                    <div class="video-border">
+                        <center>
+                            <div class="video-title">{{ chart.name }}</div>
+                        </center>
+                            <video class="video" width="100%" :poster="getThumbnailUrl(chart.folder, chart.image_thumbnail)" onmouseover="this.play();this.setAttribute('controls','controls')" onmouseout="this.load();this.removeAttribute('controls')"> <!-- use atuoplay muted to get videos to autoplay -->
+                                <source :src="getVideoUrl(chart.folder, chart.video_basename, chart.video_type)" type="video/mp4">
+                                Your browser does not support the video tag.
+                            </video>
+                    </div>
                 </div>
             </slide>
         </carousel>
@@ -53,11 +57,6 @@
             },
             getThumbnailUrl(folder, thumbnail) {
                 return 'https://labs.waterdata.usgs.gov/visualizations/river-conditions/' + folder + thumbnail;
-            },
-            handleSlideClick () {
-                this.charts.forEach(chart => {
-                    window.open(chart.drupal_url, "_blank");
-                })
             }
         }
     }
@@ -104,13 +103,25 @@
         max-width: 400px;
         align-content: center;
         justify-content: center;
-        video {
-            max-width: 430px;
-            max-height: 330px;
-            border-width: 2px;
-                border-color: #dfe1e2;
-                border-style: solid;
-                border-radius: 7px;
-        }
     }
+
+    .video-border {
+        border-width: 2px;
+        border-color: #dfe1e2;
+        border-style: solid;
+        border-radius: 7px;
+    }
+
+    .video {
+        max-width: 430px;
+        max-height: 300px;
+        margin-bottom: -7px;
+        border-radius: 7px;
+    }
+
+    .video-title {
+        margin-top: 5px;
+        margin-bottom: -5px;
+    }
+
 </style>

--- a/src/components/RiverConditions_Carousel.vue
+++ b/src/components/RiverConditions_Carousel.vue
@@ -16,12 +16,12 @@
                 <div class="slider-video-container">
                     <div class="video-border">
                         <center>
-                            <div class="video-title">{{ chart.name }}</div>
+                            <a :href="chart.drupal_url" target="_blank" class="video-title">{{ chart.name }}</a>
                         </center>
-                            <video class="video" width="100%" :poster="getThumbnailUrl(chart.folder, chart.image_thumbnail)" onmouseover="this.play();this.setAttribute('controls','controls')" onmouseout="this.load();this.removeAttribute('controls')"> <!-- use atuoplay muted to get videos to autoplay -->
-                                <source :src="getVideoUrl(chart.folder, chart.video_basename, chart.video_type)" type="video/mp4">
-                                Your browser does not support the video tag.
-                            </video>
+                        <video class="video" width="100%" :poster="getThumbnailUrl(chart.folder, chart.image_thumbnail)" controls> 
+                        <source :src="getVideoUrl(chart.folder, chart.video_basename, chart.video_type)" type="video/mp4">
+                        Your browser does not support the video tag.
+                        </video>
                     </div>
                 </div>
             </slide>


### PR DESCRIPTION
Changes made:
-----------

- This removes the `handleSlickClick` function for now, since it was opening EVERY chart in a new tab when a river conditions video was clicked. I just want to get that off the live site while I figure out how to have a singular chart open. My local build is behaving differently than the live site.
     - To refer back to that function, we can look at [this commit](https://github.com/maggiejaenicke/vizlab-home/tree/2518f90f426d8efba371fcfacfc7b5edb3db0ec6) 
- Adds dates to the river conditions cards in the carousel, as suggested
- I also updates the chart ids in `RiverConditions.js` and `FlowTiles.js` so that it will be easier to add new ones
- I'm still figuring out the Safari issue, so stay tuned--just want to get these updates in ASAP, particularly removing that function.

Keep #50 open.

Testing:
----------------------------
Before making this pull request, I:
- [ ] Cleaned the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Made sure all tests run
- [ ] Ran WAVE plugin 508 compliance tool

I can confirm this has been checked on:
- [ ] Chrome
- [ ] Safari
- [X] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)
