### PR TITLE
add new flowtiles to carousel

### DIFF
--- a/src/assets/content/FlowTiles.js
+++ b/src/assets/content/FlowTiles.js
@@ -1,6 +1,94 @@
 export default {
     flowTilesCharts: [
         {
+            id: '26',
+            folder: '2025_02/',
+            twitter_url: 'https://x.com/USGS_DataSci/status/1897692959404925333',
+            image_basename: 'flow_cartogram-feb-2025',
+            image_type: 'png',
+            image_alt: 'A tile map of the U.S. showing streamgages by flow levels through the month of February 2025. For each state, an area chart shows the proportion of streamgages in wet, normal, or dry conditions. Streamflow conditions are quantified using percentiles comparing the past month’s flow levels to the historic record for each streamgage. During the month of February, parts of the Northern Rockies saw dry conditions for states such as Montana, Wyoming, and Idaho. Concurrently, winter storms brought wet conditions to parts of the Southeast for states such as Kentucky, Tennessee, Mississippi and Louisiana.'
+        },
+        {
+            id: '25',
+            folder: '2025_01/',
+            twitter_url: 'https://x.com/USGS_DataSci/status/1887542318607016062',
+            image_basename: 'flow_cartogram-jan-2025',
+            image_type: 'png',
+            image_alt: 'A tile map of the U.S. showing streamgages by flow levels through the month of January 2025. For each state, an area chart shows the proportion of streamgages in wet, normal, or dry conditions. Streamflow conditions are quantified using percentiles comparing the past month’s flow levels to the historic record for each streamgage. During the month of January, much of the Mountain West and Southwest saw dry conditions for states such as Montana, Wyoming, Arizona, and New Mexico. Concurrently, winter storms brought wet conditions to parts of the Northwest, such as Oregon, and the Southeast, such as Louisiana, Arkansas, Tennessee, and Kentucky.'
+        },
+        {
+            id: '24',
+            folder: '2024_12/',
+            twitter_url: 'https://x.com/USGS_DataSci/status/1878845021585326208',
+            image_basename: 'flow_cartogram-dec-2024',
+            image_type: 'png',
+            image_alt: 'A tile map of the U.S. showing streamgages by flow levels through the month of December 2024. For each state, an area chart shows the proportion of streamgages in wet, normal, or dry conditions. Streamflow conditions are quantified using percentiles comparing the past month’s flow levels to the historic record for each streamgage. During the month of December, much of the Mountain West and Southwest saw dry conditions for states such as Montana, Wyoming, Arizona, and New Mexico. Concurrently, parts of the Pacific Coast saw wet conditions for states such as California, Oregon and Washington.'
+        },
+        {
+            id: '23',
+            folder: '2024_11/',
+            twitter_url: 'https://x.com/USGS_DataSci/status/1864727535558529440',
+            image_basename: 'flow_cartogram-nov-2024',
+            image_type: 'png',
+            image_alt: 'A tile map of the U.S. showing streamgages by flow levels through the month of November 2024. For each state, an area chart shows the proportion of streamgages in wet, normal, or dry conditions. Streamflow conditions are quantified using percentiles comparing the past month’s flow levels to the historic record for each streamgage. During the month of November, much of the Eastern U.S. saw dry conditions for states such as Delaware, Rhode Island, Connecticut, and New Jersey. Concurrently, Missouri, Oklahoma, and Kansas saw wet conditions.'
+        },
+        {
+            id: '22',
+            folder: '2024_10/',
+            twitter_url: 'https://x.com/USGS_DataSci/status/1854197399323136262',
+            image_basename: 'flow_cartogram-oct-2024',
+            image_type: 'png',
+            image_alt: 'A tile map of the U.S. showing streamgages by flow levels through the month of October 2024. For each state, an area chart shows the proportion of streamgages in wet, normal, or dry conditions. Streamflow conditions are quantified using percentiles comparing the past month’s flow levels to the historic record for each streamgage. During the month of October, much of the Eastern and Central U.S. saw dry conditions for states such as Delaware, Rhode Island, Connecticut, Kansas, Oklahoma, and Iowa. Concurrently, Florida and Puerto Rico saw wet conditions as tropical storms and Hurricane Helene made landfall.'
+        },
+        {
+            id: '21',
+            folder: '2024_09/',
+            twitter_url: '',
+            image_basename: 'flow_cartogram-sep-2024',
+            image_type: 'png',
+            image_alt: 'A tile map of the U.S. showing streamgages by flow levels through the month of September 2024. For each state, an area chart shows the proportion of streamgages in wet, normal, or dry conditions. Streamflow conditions are quantified using percentiles comparing the past month’s flow levels to the historic record for each streamgage. During the month of September, much of the Central and Northeastern U.S saw dry conditions for states such as Oklahoma, Kansas, Nebraska, New York, Massachusetts, New Hampshire. While others such as Alaska, Florida, and Puerto Rico saw wet conditions.'
+        },
+        {
+            id: '20',
+            folder: '2024_08/',
+            twitter_url: '',
+            image_basename: 'flow_cartogram-aug-2024',
+            image_type: 'png',
+            image_alt: 'A tile map of the U.S. showing streamgages by flow levels through the month of August 2024. For each state, an area chart shows the proportion of streamgages in wet, normal, or dry conditions. Streamflow conditions are quantified using percentiles comparing the past month’s flow levels to the historic record for each streamgage. During the month of August, much of the Midwest and Southern U.S. saw dry conditions for states such as Kansas Nebraska, Missouri, Louisiana, Mississippi, and Tennessee. While others such as Alaska, Florida, and Puerto Rico saw wet conditions.'
+        },
+        {
+            id: '19',
+            folder: '2024_07/',
+            twitter_url: 'https://x.com/USGS_DataSci/status/1819432041152422303',
+            image_basename: 'flow_cartogram-july-2024',
+            image_type: 'png',
+            image_alt: 'A tile map of the U.S. showing streamgages by flow levels through the month of July 2024. For each state, an area chart shows the proportion of streamgages in wet, normal, or dry conditions. Streamflow conditions are quantified using percentiles comparing the past month’s flow levels to the historic record for each streamgage. During the month of June, wet conditions persisted for much of the Upper Midwest for states such as Minnesota and Wisconsin, while parts of the Eastern U.S. saw dry conditions for states such as West Virginia, Virginia, Massachusetts, and New Hampshire.'
+        },
+        {
+            id: '18',
+            folder: '2024_06/',
+            twitter_url: 'https://x.com/USGS_DataSci/status/1813278914149818523',
+            image_basename: 'flow_cartogram-june-2024',
+            image_type: 'png',
+            image_alt: 'A tile map of the U.S. showing streamgages by flow levels through the month of June 2024. For each state, an area chart shows the proportion of streamgages in wet, normal, or dry conditions. Streamflow conditions are quantified using percentiles comparing the past month’s flow levels to the historic record for each streamgage. During the month of June, severe weather brought wet conditions to states such as North Dakota, Minnesota, Iowa, and Wisconsin, while dry conditions occurred for states such as Georgia, Alabama, North Carolina, and South Carolina.'
+        },
+        {
+            id: '17',
+            folder: '2024_05/',
+            twitter_url: 'https://x.com/USGS_DataSci/status/1798030050576761140',
+            image_basename: 'flow_cartogram-may-2024',
+            image_type: 'png',
+            image_alt: 'A tile map of the U.S. showing streamgages by flow levels through the month of May 2024. For each state, an area chart shows the proportion of streamgages in wet, normal, or dry conditions. Streamflow conditions are quantified using percentiles comparing the past month’s flow levels to the historic record for each streamgage. During the month of May, severe weather brought wet conditions to states such as Minnesota, Iowa, and Missouri, while dry conditions occurred for states such as Arizona, New Mexico and Kansas.'
+        },
+        {
+            id: '16',
+            folder: '2024_04/',
+            twitter_url: 'https://x.com/USGS_DataSci/status/1787946014797951150',
+            image_basename: 'flow_cartogram-apr-2024',
+            image_type: 'png',
+            image_alt: 'A tile map of the U.S. showing streamgages by flow levels through the month of April 2024. For each state, an area chart shows the proportion of streamgages in wet, normal, or dry conditions. Streamflow conditions are quantified using percentiles comparing the past month’s flow levels to the historic record for each streamgage. During the month of April, storm systems brought wet conditions to much of the Midwestern and Northeastern U.S. for states such as Indiana, Ohio, Pennsylvania, Massachusetts, and Rhode Island.'
+        },
+        {
             id: '15',
             folder: '2024_03/',
             twitter_url: 'https://twitter.com/USGS_DataSci/status/1775549094259511449',


### PR DESCRIPTION
Changes made: Added 2024_04 - 2025_02 flowtiles materials in `FlowTiles.js` and associated aws content in folders. 
-----------
Description
Hey Hayley, I added all the updated versions of flowtiles to the carousel. I'm going to ask Kim about the Drupal content and I'll get back to you. 

Testing:
----------------------------
Before making this pull request, I:
- [ ] Cleaned the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Made sure all tests run
- [ ] Ran WAVE plugin 508 compliance tool

I can confirm this has been checked on:
- [x] Chrome
- [x] Safari
- [x] Edge
- [x] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

## Chrome
<img width="1244" alt="Screenshot 2025-03-06 at 9 31 53 AM" src="https://github.com/user-attachments/assets/a880b4e1-f930-4867-8e88-9929e4903d86" />

## Safari
<img width="1204" alt="Screenshot 2025-03-06 at 9 35 38 AM" src="https://github.com/user-attachments/assets/412d9923-90c6-45a7-9904-bb185ec9097a" />

## Edge
<img width="1239" alt="Screenshot 2025-03-06 at 9 35 59 AM" src="https://github.com/user-attachments/assets/6c6fb960-c2ab-4f89-a8bb-58e8af676233" />

## Firefox
<img width="1404" alt="Screenshot 2025-03-06 at 9 36 53 AM" src="https://github.com/user-attachments/assets/3660ee06-5656-400a-84e7-02d0ec0234e1" />

