### PR TITLE
Add april & may 2025 flowtiles to viz home

### DIFF
--- a/code.json
+++ b/code.json
@@ -3,7 +3,7 @@
     "name": "vizlab-home",
     "organization": "U.S. Geological Survey",
     "description": "Landing page for the USGS Vizlab",
-    "version": "0.13.7",
+    "version": "0.13.8",
     "status": "Production",
     "permissions": {
       "usageType": "openSource",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vizlab-home",
-  "version": "0.13.7",
+  "version": "0.13.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vizlab-home",
-      "version": "0.13.7",
+      "version": "0.13.8",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.36",
         "@fortawesome/free-brands-svg-icons": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vizlab-home",
-  "version": "0.13.7",
+  "version": "0.13.8",
   "private": true,
   "scripts": {
     "serve": "env NODE_OPTIONS=--openssl-legacy-provider vue-cli-service serve --mode test_tier",

--- a/src/assets/content/FlowTiles.js
+++ b/src/assets/content/FlowTiles.js
@@ -1,6 +1,22 @@
 export default {
     flowTilesCharts: [
         {
+            id: '29',
+            folder: '2025_05/',
+            twitter_url: 'https://x.com/USGS_DataSci/status/1929924020004147635',
+            image_basename: 'flow_cartogram-may-2025',
+            image_type: 'png',
+            image_alt: 'A tile map of the U.S. showing streamgages by flow levels through the month of May 2025. For each state, an area chart shows the proportion of streamgages in wet, normal, or dry conditions. Streamflow conditions are quantified using percentiles comparing the past month’s flow levels to the historic record for each streamgage. During the month of May, wet conditions persisted in the Northeast and Mid-Atlantic states like New York, Pennsylvania, and Vermont. In contrast, dry conditions persisted in Florida, Arizona, and New Mexico.'
+        },
+        {
+            id: '28',
+            folder: '2025_04/',
+            twitter_url: 'https://x.com/USGS_DataSci/status/1919446545654489325',
+            image_basename: 'flow_cartogram-apr-2025',
+            image_type: 'png',
+            image_alt: 'A tile map of the U.S. showing streamgages by flow levels through the month of April 2025. For each state, an area chart shows the proportion of streamgages in wet, normal, or dry conditions. Streamflow conditions are quantified using percentiles comparing the past month’s flow levels to the historic record for each streamgage. During the month of April, wet conditions were prevalent in the Midwest and Northeast, including states like Wisconsin, Indiana, Vermont, and Maine. Meanwhile, dry conditions dominated parts of the Southeast and Southwest, especially in Florida, New Mexico, and Arizona.'
+        },
+        {
             id: '27',
             folder: '2025_03/',
             twitter_url: 'https://x.com/USGS_DataSci/status/1907870314681221497',


### PR DESCRIPTION
Changes made:
-----------
Description

Hey Hayley, I added the April and May 2025 flowtiles to vizlab home page. Tested and could be good to go. Let me know if there's any issues. 

<img width="1263" alt="Screenshot 2025-06-04 at 12 43 49 PM" src="https://github.com/user-attachments/assets/7cbf47c5-193d-4827-b8b8-f1b4112bdc3c" />


Testing:
----------------------------
Before making this pull request, I:
- [ ] Cleaned the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Made sure all tests run
- [ ] Ran WAVE plugin 508 compliance tool

I can confirm this has been checked on:
- [x] Chrome
- [x] Safari
- [x] Edge
- [x] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)
