### PR TITLE
add july and aug 25 flow

### DIFF
--- a/code.json
+++ b/code.json
@@ -3,7 +3,7 @@
     "name": "vizlab-home",
     "organization": "U.S. Geological Survey",
     "description": "Landing page for the USGS Vizlab",
-    "version": "0.13.9",
+    "version": "0.14.0",
     "status": "Production",
     "permissions": {
       "usageType": "openSource",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vizlab-home",
-  "version": "0.13.9",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vizlab-home",
-      "version": "0.13.9",
+      "version": "0.14.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.36",
         "@fortawesome/free-brands-svg-icons": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vizlab-home",
-  "version": "0.13.9",
+  "version": "0.14.0",
   "private": true,
   "scripts": {
     "serve": "env NODE_OPTIONS=--openssl-legacy-provider vue-cli-service serve --mode test_tier",

--- a/src/assets/content/FlowTiles.js
+++ b/src/assets/content/FlowTiles.js
@@ -1,6 +1,22 @@
 export default {
     flowTilesCharts: [
         {
+            id: '32',
+            folder: '2025_08/',
+            twitter_url: 'https://x.com/USGS_Water/status/1965102031225700461',
+            image_basename: 'flow_cartogram-aug-2025',
+            image_type: 'png',
+            image_alt: 'A tile map of the U.S. showing streamgages by flow levels through the month of August 2025. For each state, an area chart shows the proportion of streamgages in wet, normal, or dry conditions. Streamflow conditions are quantified using percentiles comparing the past month’s flow levels to the historic record for each streamgage. During the month of August, dry conditions expanded across the Northeast, Southeast and Southwest, while parts of the Midwest and South Atlantic saw wet conditions.'
+        },
+        {
+            id: '31',
+            folder: '2025_07/',
+            twitter_url: 'https://x.com/USGS_Water/status/1957505329102508491',
+            image_basename: 'flow_cartogram-july-2025',
+            image_type: 'png',
+            image_alt: 'A tile map of the U.S. showing streamgages by flow levels through the month of July 2025. For each state, an area chart shows the proportion of streamgages in wet, normal, or dry conditions. Streamflow conditions are quantified using percentiles comparing the past month’s flow levels to the historic record for each streamgage. During the month of July, dry conditions persisted across parts of the Northeast, Mid-Atlantic, and Southwest, while wet conditions expanded across parts of the Upper Midwest.'
+        },
+        {
             id: '30',
             folder: '2025_06/',
             twitter_url: 'https://x.com/USGS_Water/status/1942234704234627072',


### PR DESCRIPTION
Changes made:
-----------
Description

Hey Hayley, I added the July and August 2025 flowtiles to vizlab home page. Tested and could be good to go. Let me know if there's any issues. 

<img width="1380" height="234" alt="Screenshot 2025-09-08 at 10 33 21 AM" src="https://github.com/user-attachments/assets/b4e6915d-057f-480b-a4c7-621b763631ba" />

also updated version in `code.json` and `package.json` and ran `npm install` like previously suggested. 

Testing:
----------------------------
Before making this pull request, I:
- [ ] Cleaned the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Made sure all tests run
- [ ] Ran WAVE plugin 508 compliance tool

I can confirm this has been checked on:
- [x] Chrome
- [x] Safari
- [x] Edge
- [x] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)