### PR TITLE
Add nwdc blog and fy26q2 river cond

### DIFF
--- a/src/assets/content/blogs.json
+++ b/src/assets/content/blogs.json
@@ -1,6 +1,18 @@
 {
   "items": [
     {
+      "id": "nwdc-inset-map-tutorial",
+      "title": "Purrrfect mini-maps - Visualizing water availability across the U.S.",
+      "released": "04/20/2026",
+      "image": {
+        "alt": "Paired maps and timeserires chart of SUI for each HUC04 in the Great Basin (HUC02 id 16).",
+        "thumbnail": "https://waterdata.usgs.gov/blog/static/nwdc-inset-map-tutorial/mini-map-insets-thumbnail.png"
+      },
+      "links": {
+        "external": "https://waterdata.usgs.gov/blog/nwdc-inset-map-tutorial/"
+      }
+    },
+    {
       "id": "vizlab-stream-names-map",
       "title": "A map that glows with the vocabulary of water",
       "released": "02/27/2026",

--- a/src/assets/content/series.json
+++ b/src/assets/content/series.json
@@ -528,6 +528,18 @@
       ],
       "items": [
         {
+          "id": "river_conditions_jan_mar_2026_insta",
+          "title": "January 1, 2026 - March 31, 2026",
+          "released": "2026-04-02",
+          "image": {
+            "alt": "U.S. River Conditions from January 1, 2026 to March 31, 2026 at USGS streamgages.",
+            "thumbnail": "FY26_Q2/river_conditions_jan_mar_2026_square_thumbnail.png"
+          },
+          "links": {
+            "external": "https://www.usgs.gov/media/videos/us-river-conditions-january-march-2026"
+          }
+        },
+        {
           "id": "river_conditions_oct_dec_2025_insta",
           "title": " October 1, 2025 - December 31, 2025",
           "released": "2026-01-01",


### PR DESCRIPTION
Small PR to add [NWDC mini maps blog ](https://waterdata.usgs.gov/blog/nwdc-inset-map-tutorial/) and [FY26Q2 River Conditions content](https://www.usgs.gov/media/videos/us-river-conditions-january-march-2026). 

To test:
- pull branch
- `npm i`
- `npm run dev`

<img width="1224" height="936" alt="Screenshot 2026-04-22 at 10 21 28 AM" src="https://github.com/user-attachments/assets/89bfda7f-8681-4a2b-ab90-88bd0efde6a6" />
<img width="1188" height="869" alt="Screenshot 2026-04-22 at 10 21 43 AM" src="https://github.com/user-attachments/assets/0d32a8b5-a09e-4285-84e5-8a95a2aa425c" />


Once this is merged I will updated on NatWeb to ensure the content is up to date. 