### PR TITLE
Add april 2026 flowtiles

### DIFF
--- a/src/assets/content/series.json
+++ b/src/assets/content/series.json
@@ -9,6 +9,19 @@
       ],
       "items": [
         {
+          "id": "flow_cartogram-apr-2026",
+          "title": "April 2026",
+          "released": "2026-04-01",
+          "image": {
+            "alt": "A tile map of the U.S. showing streamgages by flow levels through the month of April 2026. For each state, an area chart shows the proportion of streamgages in wet, normal, or dry conditions. Streamflow conditions are quantified using percentiles comparing the past month’s flow levels to the historic record for each streamgage.",
+            "thumbnail": "2026_04/flow_cartogram-apr-2026.png"
+          },
+          "links": {
+            "x": "",
+            "external": "2026_04/flow_cartogram-apr-2026.png"
+          }
+        },
+        {
           "id": "flow_cartogram-mar-2026",
           "title": "March 2026",
           "released": "2026-03-01",


### PR DESCRIPTION
Changes made:
-----------
Description

Small PR to add Apriil 2026 flowtiles

<img width="993" height="505" alt="Screenshot 2026-05-05 at 7 30 33 AM" src="https://github.com/user-attachments/assets/ab1f15b7-2f7d-4598-ade1-abd798531344" />


Testing:
----------------------------
Before making this pull request, I:
- [ ] Cleaned the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Made sure all tests run
- [ ] Ran WAVE plugin 508 compliance tool

I can confirm this has been checked on:
- [x] Chrome
- [x] Safari
- [x] Edge
- [x] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)